### PR TITLE
Add Logary licence change issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ lerna/lerna
 * [/issues/1632](https://github.com/lerna/lerna/issues/1632)
 * [/pull/1633](https://github.com/lerna/lerna/pull/1633)
 
+[logary/logary/issues/345](https://github.com/logary/logary/issues/345)
+
 [Microsoft/TypeScript/pull/3622](https://github.com/Microsoft/TypeScript/pull/3622)
 
 [Microsoft/web-build-tools/issues/673](https://github.com/Microsoft/web-build-tools/issues/673)


### PR DESCRIPTION
The copyright holder of Logary decided to go for mixed licensing. Was not welcomed by the community.